### PR TITLE
Retry request if response is not OK

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = function(url, options) {
     var wrappedFetch = function(n) {
       fetch(url, options)
         .then(function(response) {
+          if (!response.ok) throw new Error();
           resolve(response);
         })
         .catch(function(error) {


### PR DESCRIPTION
While using the package server side, looks like 500-ish errors are handled as ok and does not retry.
Client-side works properly and if fetch gets a 503 it will retry connection.

This PR pretends to fix this issue server-side to behave similar to client-side using `response.ok` to understand if request is valid.