### PR TITLE
Global fetch variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
-var fetch = require('isomorphic-fetch');
-var Promise = require('es6-promise');
+require('isomorphic-fetch');
+require('es6-promise').polyfill();
 
 module.exports = function(url, options) {
   var retries = 3;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fetch-retry",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetch-retry",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Adds retry functionality to the Fetch API",
   "repository": "https://github.com/jonbern/fetch-retry.git",
   "main": "index.js",

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,4 +1,5 @@
 'use strict';
+require('isomorphic-fetch');
 var proxyquire = require('proxyquire').noPreserveCache();
 var sinon = require('sinon');
 var expect = require('expectations');
@@ -7,7 +8,6 @@ var Promise = require('es6-promise');
 describe('fetch-retry', function() {
 
   var fetchRetry;
-  var fetch;
 
   var deferred1;
   var deferred2;


### PR DESCRIPTION
Using global variable for `fetch` as recommended by @matt2xu.