### PR TITLE
Support 0, null, and undefined for the retries and retryDelay options

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,11 +7,11 @@ module.exports = function(url, options) {
   var retryDelay = 1000;
   var retryOn = [];
 
-  if (options && options.retries) {
+  if (options && options.retries != null) {
     retries = options.retries;
   }
 
-  if (options && options.retryDelay) {
+  if (options && options.retryDelay != null) {
     retryDelay = options.retryDelay;
   }
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -342,6 +342,60 @@ describe('fetch-retry', function() {
 
   });
 
+  describe('when #options.retries=0', function() {
+
+    beforeEach(function() {
+      thenCallback = sinon.spy();
+      catchCallback = sinon.spy();
+
+      fetchRetry('http://someurl', { retries: 0 })
+        .then(thenCallback)
+        .catch(catchCallback);
+    });
+
+    describe('when first call is a success', function() {
+
+      beforeEach(function() {
+        deferred1.resolve({ status: 200 });
+      });
+
+      describe('when resolved', function() {
+
+        it('invokes the then callback', function() {
+          expect(thenCallback.called).toBe(true);
+        });
+
+        it('calls fetch once', function() {
+          expect(fetch.callCount).toBe(1);
+        });
+
+      });
+
+    });
+
+    describe('when first call is a failure', function() {
+
+      beforeEach(function() {
+        deferred1.reject();
+        clock.tick(delay);
+      });
+
+      describe('when rejected', function() {
+
+        it('invokes the catch callback', function() {
+          expect(catchCallback.called).toBe(true);
+        });
+
+        it('does not call fetch again', function() {
+          expect(fetch.callCount).toBe(1);
+        });
+
+      });
+
+    });
+
+  });
+
   describe('when #options.retryDelay is provided', function() {
 
     var options;
@@ -385,6 +439,45 @@ describe('fetch-retry', function() {
 
         it('does not invoke fetch again', function() {
           expect(fetch.callCount).toBe(1);
+        });
+
+      });
+
+    });
+
+  });
+
+  describe('when #options.retryDelay is zero', function() {
+
+    var options;
+    var retryDelay;
+
+    beforeEach(function() {
+      retryDelay = 0;
+      options = {
+        retryDelay: retryDelay
+      };
+
+      thenCallback = sinon.spy();
+
+      fetchRetry('http://someUrl', options)
+        .then(thenCallback);
+    });
+
+    describe('when first call is unsuccessful', function() {
+
+      beforeEach(function() {
+        deferred1.reject();
+      });
+
+      describe('after specified time', function() {
+
+        beforeEach(function() {
+          clock.tick(retryDelay);
+        });
+
+        it('invokes fetch again', function() {
+          expect(fetch.callCount).toBe(2);
         });
 
       });

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -400,49 +400,55 @@ describe('fetch-retry', function() {
 
   });
 
-  describe('when #options.retryDelay is provided', function() {
+  [
+    [undefined, 1000],
+    [null, 1000],
+    [5000, 5000]
+  ].forEach(function([retryDelay, actualDelay]) {
 
-    var options;
-    var retryDelay;
+    describe('when #options.retryDelay is ' + retryDelay, function() {
 
-    beforeEach(function() {
-      retryDelay = 5000;
-      options = {
-        retryDelay: retryDelay
-      };
-
-      thenCallback = sinon.spy();
-
-      fetchRetry('http://someUrl', options)
-        .then(thenCallback)
-    });
-
-    describe('when first call is unsuccessful', function() {
+      var options;
 
       beforeEach(function() {
-        deferred1.reject();
+        options = {
+          retryDelay: retryDelay
+        };
+
+        thenCallback = sinon.spy();
+
+        fetchRetry('http://someUrl', options)
+          .then(thenCallback)
       });
 
-      describe('after specified time', function() {
+      describe('when first call is unsuccessful', function() {
 
         beforeEach(function() {
-          clock.tick(retryDelay);
+          deferred1.reject();
         });
 
-        it('invokes fetch again', function() {
-          expect(fetch.callCount).toBe(2);
+        describe('after specified time', function() {
+
+          beforeEach(function() {
+            clock.tick(actualDelay);
+          });
+
+          it('invokes fetch again', function() {
+            expect(fetch.callCount).toBe(2);
+          });
+
         });
 
-      });
+        describe('after less than specified time', function() {
 
-      describe('after less than specified time', function() {
+          beforeEach(function() {
+            clock.tick(actualDelay / 2);
+          });
 
-        beforeEach(function() {
-          clock.tick(1000);
-        });
+          it('does not invoke fetch again', function() {
+            expect(fetch.callCount).toBe(1);
+          });
 
-        it('does not invoke fetch again', function() {
-          expect(fetch.callCount).toBe(1);
         });
 
       });

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -115,48 +115,23 @@ describe('fetch-retry', function() {
 
   });
 
-  describe('when #options.retries=3 (default)', function() {
+  [undefined, null, 3].forEach(function(testCase) {
 
-    beforeEach(function() {
-      thenCallback = sinon.spy();
-      catchCallback = sinon.spy();
-
-      fetchRetry('http://someurl')
-        .then(thenCallback)
-        .catch(catchCallback);
-    });
-
-    describe('when first call is a success', function() {
+    describe('when #options.retries=' + testCase, function() {
 
       beforeEach(function() {
-        deferred1.resolve({ status: 200 });
+        thenCallback = sinon.spy();
+        catchCallback = sinon.spy();
+
+        fetchRetry('http://someurl', { retries: testCase })
+          .then(thenCallback)
+          .catch(catchCallback);
       });
 
-      describe('when resolved', function() {
-
-        it('invokes the then callback', function() {
-          expect(thenCallback.called).toBe(true);
-        });
-
-        it('calls fetch once', function() {
-          expect(fetch.callCount).toBe(1);
-        });
-
-      });
-
-    });
-
-    describe('when first call is a failure', function() {
-
-      beforeEach(function() {
-        deferred1.reject();
-      });
-
-      describe('when second call is a succcess', function() {
+      describe('when first call is a success', function() {
 
         beforeEach(function() {
-          clock.tick(delay);
-          deferred2.resolve({ status: 200 });
+          deferred1.resolve({ status: 200 });
         });
 
         describe('when resolved', function() {
@@ -165,26 +140,25 @@ describe('fetch-retry', function() {
             expect(thenCallback.called).toBe(true);
           });
 
-          it('calls fetch twice', function() {
-            expect(fetch.callCount).toBe(2);
+          it('calls fetch once', function() {
+            expect(fetch.callCount).toBe(1);
           });
 
         });
 
       });
 
-      describe('when second call is a failure', function() {
+      describe('when first call is a failure', function() {
 
         beforeEach(function() {
-          deferred2.reject();
-          clock.tick(delay);
+          deferred1.reject();
         });
 
-        describe('when third call is a success', function() {
+        describe('when second call is a succcess', function() {
 
           beforeEach(function() {
-            deferred3.resolve({ status: 200 });
             clock.tick(delay);
+            deferred2.resolve({ status: 200 });
           });
 
           describe('when resolved', function() {
@@ -193,25 +167,25 @@ describe('fetch-retry', function() {
               expect(thenCallback.called).toBe(true);
             });
 
-            it('calls fetch three times', function() {
-              expect(fetch.callCount).toBe(3);
+            it('calls fetch twice', function() {
+              expect(fetch.callCount).toBe(2);
             });
 
           });
 
         });
 
-        describe('when third call is a failure', function() {
+        describe('when second call is a failure', function() {
 
           beforeEach(function() {
-            deferred3.reject();
+            deferred2.reject();
             clock.tick(delay);
           });
 
-          describe('when fourth call is a success', function() {
+          describe('when third call is a success', function() {
 
             beforeEach(function() {
-              deferred4.resolve({ status: 200 });
+              deferred3.resolve({ status: 200 });
               clock.tick(delay);
             });
 
@@ -221,29 +195,59 @@ describe('fetch-retry', function() {
                 expect(thenCallback.called).toBe(true);
               });
 
-              it('calls fetch four times', function() {
-                expect(fetch.callCount).toBe(4);
+              it('calls fetch three times', function() {
+                expect(fetch.callCount).toBe(3);
               });
 
             });
 
           });
 
-          describe('when fourth call is a failure', function() {
+          describe('when third call is a failure', function() {
 
             beforeEach(function() {
-              deferred4.reject();
+              deferred3.reject();
               clock.tick(delay);
             });
 
-            describe('when rejected', function() {
+            describe('when fourth call is a success', function() {
 
-              it('invokes the catch callback', function() {
-                expect(catchCallback.called).toBe(true);
+              beforeEach(function() {
+                deferred4.resolve({ status: 200 });
+                clock.tick(delay);
               });
 
-              it('does not call fetch again', function() {
-                expect(fetch.callCount).toBe(4);
+              describe('when resolved', function() {
+
+                it('invokes the then callback', function() {
+                  expect(thenCallback.called).toBe(true);
+                });
+
+                it('calls fetch four times', function() {
+                  expect(fetch.callCount).toBe(4);
+                });
+
+              });
+
+            });
+
+            describe('when fourth call is a failure', function() {
+
+              beforeEach(function() {
+                deferred4.reject();
+                clock.tick(delay);
+              });
+
+              describe('when rejected', function() {
+
+                it('invokes the catch callback', function() {
+                  expect(catchCallback.called).toBe(true);
+                });
+
+                it('does not call fetch again', function() {
+                  expect(fetch.callCount).toBe(4);
+                });
+
               });
 
             });


### PR DESCRIPTION
This is a re-submit of #13, with a rework of the tests to ensure that passing `null` or `undefined` to `options.retries` and `options.retryDelay` results in using the default number of retries (3), and the default retry delay (1000), respectively.

The diff is a bit easier to review with `?w=1` to ignore the re-indentation of some tests.