### PR TITLE
Using cross-fetch over isomorphic-fetch to support React Native

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Adds retry functionality to the `Fetch` API.
 
-It wraps [isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch) and retries requests that fail due to network issues. It can also be configured to retry requests on specific HTTP status codes.
+It wraps [cross-fetch](https://github.com/lquixada/cross-fetch)(owing to support for browser, Node & React Native)  and retries requests that fail due to network issues. It can also be configured to retry requests on specific HTTP status codes.
 
 [![Build Status](https://travis-ci.org/jonbern/fetch-retry.svg?branch=master)](https://travis-ci.org/jonbern/fetch-retry)
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
-require('isomorphic-fetch');
 require('es6-promise').polyfill();
+var fetch = require('cross-fetch');
 
 module.exports = function(url, options) {
   var retries = 3;

--- a/package-lock.json
+++ b/package-lock.json
@@ -547,6 +547,27 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "cross-fetch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
+      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+      "requires": {
+        "node-fetch": "2.6.0",
+        "whatwg-fetch": "3.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        },
+        "whatwg-fetch": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+          "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -643,14 +664,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1156,11 +1169,6 @@
         "toidentifier": "1.0.0"
       }
     },
-    "iconv-lite": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.16.tgz",
-      "integrity": "sha1-Zd477rOeKWDWfwSfFjT/y83pAUs="
-    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1270,7 +1278,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "isarray": {
       "version": "0.0.1",
@@ -1283,15 +1292,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
@@ -1703,15 +1703,6 @@
             "isarray": "0.0.1"
           }
         }
-      }
-    },
-    "node-fetch": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-      "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "normalize-package-data": {
@@ -2636,11 +2627,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
-    },
-    "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "author": "Jon K. Bernhardsen",
   "license": "MIT",
   "dependencies": {
-    "es6-promise": "^4.2.8",
-    "isomorphic-fetch": "^2.2.1"
+    "cross-fetch": "^3.0.4",
+    "es6-promise": "^4.2.8"
   },
   "devDependencies": {
     "body-parser": "^1.19.0",

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,5 +1,5 @@
 'use strict';
-require('isomorphic-fetch');
+require('cross-fetch');
 var proxyquire = require('proxyquire').noPreserveCache();
 var sinon = require('sinon');
 var expect = require('expectations');
@@ -42,7 +42,7 @@ describe('fetch-retry', function() {
     fetch.onCall(3).returns(deferred4.promise);
 
     var stubs = {
-      'isomorphic-fetch': fetch
+      'cross-fetch': fetch
     };
 
     fetchRetry = proxyquire('../../', stubs);


### PR DESCRIPTION
We're looking to use `fetch-retry` for React Native. Currently `isomorphic-fetch` doesn't work reliably and thus `cross-fetch` is advised and works https://github.com/matthew-andrews/isomorphic-fetch/issues/125#issuecomment-334014834.

I've run tests ✅ 