### PR TITLE
feat: Retry Custom Behavior with Async and Await

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,26 @@ fetch(url, {
       console.log(json);
     });
 ```
+
+## Example: Retry custom behavior with async
+The `retryOn` option may also be used with async and await for calling asyncronous functions:
+
+```javascript
+fetch(url, {
+    retryOn: async function(attempt, error, response) {
+      if (attempt > 3) return false;
+
+      if (error !== null) {
+        var json = await response.json();
+        if (json.property !== undefined) {
+          return true;
+        }
+      }
+    })
+    .then(function(response) {
+      return response.json();
+    }).then(function(json) {
+      // do something with the result
+      console.log(json);
+    });
+```

--- a/index.js
+++ b/index.js
@@ -38,8 +38,17 @@ module.exports = function(url, options) {
           if (Array.isArray(retryOn) && retryOn.indexOf(response.status) === -1) {
             resolve(response);
           } else if (typeof retryOn === 'function') {
-            if (retryOn(attempt, null, response)) {
+            var retryOnRes = retryOn(attempt, null, response);
+            if (typeof retryOnRes === 'boolean' && retryOnRes) {
               retry(attempt, null, response);
+            } else if (typeof retryOnRes === 'object' && typeof retryOnRes.then === 'function') {
+              retryOnRes.then((res) => {
+                if(res){
+                  retry(attempt, null, response);
+                } else {
+                  resolve(response);
+                }
+              })
             } else {
               resolve(response);
             }

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function(url, options) {
           if (Array.isArray(retryOn) && retryOn.indexOf(response.status) === -1) {
             resolve(response);
           } else if (typeof retryOn === 'function') {
-            var retryOnRes = retryOn(attempt, null, response);
+            var retryOnRes = retryOn(attempt, null, {...response});
             if (typeof retryOnRes === 'boolean' && retryOnRes) {
               retry(attempt, null, response);
             } else if (typeof retryOnRes === 'object' && typeof retryOnRes.then === 'function') {

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -829,6 +829,69 @@ describe('fetch-retry', function() {
 
       });
 
+      describe('when first attempt is resolved with Promise', function() {
+
+        describe('when #retryOn() returns Promise with true resolve', () => {
+
+          beforeEach(function() {
+            retryOn.returns(new Promise((resolve) => resolve(true)));
+            deferred1.resolve({ status: 200 });
+          });
+
+          describe('after specified delay', () => {
+
+            beforeEach(function() {
+              clock.tick(delay);
+            });
+
+            it('calls fetch again', function() {
+              expect(fetch.callCount).toBe(2);
+            });
+
+            describe('when second call is resolved', () => {
+
+              beforeEach(function() {
+                deferred2.resolve({ status: 200 });
+                clock.tick(delay);
+              });
+
+              it('invokes the #retryOn function with the response', function() {
+                expect(retryOn.called).toBe(true);
+                expect(retryOn.lastCall.args.length).toBe(3);
+                expect(retryOn.lastCall.args[0]).toBe(0);
+                expect(retryOn.lastCall.args[1]).toBe(null);
+                expect(retryOn.lastCall.args[2]).toEqual({ status: 200 });
+              });
+
+            });
+
+          });
+
+        });
+
+        describe('when #retryOn() returns Promise with false resolve', () => {
+
+          beforeEach(function() {
+            retryOn.returns(new Promise((resolve) => resolve(false)));
+            deferred1.resolve({ status: 502 });
+          });
+
+          describe('when resolved', () => {
+
+            it('invokes the then callback', function() {
+              expect(thenCallback.called).toBe(true);
+            });
+
+            it('calls fetch 1 time only', function() {
+              expect(fetch.callCount).toBe(1);
+            });
+
+          });
+
+        });
+
+      });
+
     });
 
     describe('when #options.retryOn is not an array or function', function() {


### PR DESCRIPTION
## Example: Retry custom behavior with async
The `retryOn` option may also be used with async and await for calling asyncronous functions:
```javascript
fetch(url, {
    retryOn: async function(attempt, error, response) {
      if (attempt > 3) return false;
      if (error !== null) {
        var json = await response.json();
        if (json.property !== undefined) {
          return true;
        }
      }
    })
    .then(function(response) {
      return response.json();
    }).then(function(json) {
      // do something with the result
      console.log(json);
    });
```

fixes #29 