### PR TITLE
Reference TypeScript DOM lib explicitly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference lib="dom" />
+
 declare module 'fetch-retry' {
   const _fetch: typeof fetch;
 


### PR DESCRIPTION
Currently, TypeScript has to have `dom` in `tsconfig.compilerOptions.lib` for the definitions to work. Otherwise, the global definitions for `Response` etc. are not resolved. We have a node.js project and for certain reasons do not want to add DOM as our lib dependency.

By using a [Triple-Slash Directive](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html) the type definition file can explicitly include an existing built-in lib file.

I believe this is a safe update.