### PR TITLE
Feature/enforce es5

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,8 +1,10 @@
 env:
   browser: true
   commonjs: true
-  es6: true
+  es6: false
 extends: 'eslint:recommended'
+parserOptions:
+  ecmaVersion: 5
 rules:
   indent:
     - warn

--- a/index.js
+++ b/index.js
@@ -60,7 +60,6 @@ module.exports = function (fetch, defaults) {
       }
     }
 
-    // eslint-disable-next-line no-undef
     return new Promise(function (resolve, reject) {
       var wrappedFetch = function (attempt) {
         fetch(input, init)

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ module.exports = function (fetch, defaults) {
       }
     }
 
+    // eslint-disable-next-line no-undef
     return new Promise(function (resolve, reject) {
       var wrappedFetch = function (attempt) {
         fetch(input, init)

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function (fetch, defaults) {
     retryDelay: 1000,
     retryOn: [],
   };
-  
+
   defaults = Object.assign(baseDefaults, defaults);
 
   return function fetchRetry(input, init) {
@@ -60,6 +60,7 @@ module.exports = function (fetch, defaults) {
       }
     }
 
+    // eslint-disable-next-line no-undef
     return new Promise(function (resolve, reject) {
       var wrappedFetch = function (attempt) {
         fetch(input, init)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "nyc mocha test/**/**.js",
+    "lint":"eslint index.js ./test/**/*.js",
+    "test": "nyc mocha test/**/**.js && npm run lint",
     "integration-test": "mocha test/integration/"
   },
   "keywords": [

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -2,6 +2,6 @@ env:
   node: true
   mocha: true
 parserOptions:
-  ecmaVersion: 9
+  ecmaVersion: 10
 rules:
   no-console: 0

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -382,8 +382,8 @@ describe('fetch-retry', function () {
             expect(fetch.callCount).toBe(1);
           });
         });
-      })
-    })
+      });
+    });
 
     describe('when #init.retries=1', function () {
 


### PR DESCRIPTION
As suggested by @ptolemybarnes in #42: update eslintrc.yml to check for es5 syntax.

This PR also updates the test script to run eslint as part of the build in order to catch any syntax that is not es5 compatible.