### PR TITLE
Support Request Arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,8 @@ module.exports = function (fetch, defaults) {
     // eslint-disable-next-line no-undef
     return new Promise(function (resolve, reject) {
       var wrappedFetch = function (attempt) {
-        fetch(input, init)
+        var _input = input instanceof Request ? input.clone() : input;
+        fetch(_input, init)
           .then(function (response) {
             if (Array.isArray(retryOn) && retryOn.indexOf(response.status) === -1) {
               resolve(response);


### PR DESCRIPTION
The first parameter to`fetch` can be either be a URL or a `Request` object:

[WindowOrWorkerGlobalScope.fetch() - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters)

When a `Request` object is passed to this library, a `TypeError` is thrown upon retries:
> Failed to execute 'fetch' on 'Window': Cannot construct a Request with a Request object that has already been used.

The fix is to use a fresh `Request` instance for each retry.