### PR TITLE
fix: use default export in module declaration (#1)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,5 +22,5 @@ declare module 'fetch-retry' {
   }
 
   function fetchBuilder(fetch: typeof _fetch, defaults?: object): ((input: RequestInfo, init?: RequestInitWithRetry) => Promise<Response>);
-  export = fetchBuilder;
+  export default fetchBuilder;
 }


### PR DESCRIPTION
With two exports in the module declaration file I get a `An export assignment cannot be used in a module with other exported elements` error when compiling in a Typescript project.

Using `export default` instead of `export =` for the `fetchBuilder` export fixes the problem for me. Not sure if there are any side effects though.