### PR TITLE
Replaced npm prepare step to fix fail to install

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "nyc mocha test/**/**.js && npm run lint",
     "integration-test": "mocha test/integration/",
     "build": "rollup -c",
-    "prepare": "husky install"
+    "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\""
   },
   "keywords": [
     "fetch",


### PR DESCRIPTION
If `husky` is not present, `npm` fails to install `fetch-retry` as a dependency for `production` or `ci` environments.

```
npm ERR! code 127
npm ERR! git dep preparation failed
npm ERR! command /home/ubuntu/.nvm/versions/node/v12.22.10/bin/node /home/ubuntu/.nvm/versions/node/v12.22.10/lib/node_modules/npm/bin/npm-cli.js install --force --cache=/home/ubuntu/.npm --prefer-offline=false --prefer-online=false --offline=false --no-progress --no-save --no-audit
npm ERR! > fetch-retry@5.0.1 prepare
npm ERR! > husky install
npm ERR! npm WARN using --force Recommended protections disabled.
npm ERR! sh: 1: husky: not found
npm ERR! npm ERR! code 127
npm ERR! npm ERR! path /home/ubuntu/.npm/_cacache/tmp/git-clone-9f0cb372
npm ERR! npm ERR! command failed
npm ERR! npm ERR! command sh -c husky install
npm ERR!
npm ERR! npm ERR! A complete log of this run can be found in:
npm ERR! npm ERR!     /home/ubuntu/.npm/_logs/2022-02-21T00_27_56_429Z-debug.log

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/ubuntu/.npm/_logs/2022-02-21T00_27_56_749Z-debug.log
```

They offer a few alternative to the "default install" here: https://typicode.github.io/husky/#/?id=disable-husky-in-cidockerprod.

See also https://github.com/typicode/husky/issues/914.