### PR TITLE
Add node-fetch 3.x.x compatibility

### DIFF
--- a/dist/fetch-retry.umd.js
+++ b/dist/fetch-retry.umd.js
@@ -67,7 +67,7 @@
       return new Promise(function (resolve, reject) {
         var wrappedFetch = function (attempt) {
           var _input =
-            typeof Request !== 'undefined' && input instanceof Request
+            (typeof input === 'object' && input !==null && 'clone' in input && typeof input.clone === 'function')
               ? input.clone()
               : input;
           fetch(_input, init)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,26 +1,31 @@
 /// <reference lib="dom" />
 
 declare module 'fetch-retry' {
-  const _fetch: typeof fetch;
-
-  type RequestDelayFunction = ((
+  type RequestDelayFunction<TResponse> = ((
     attempt: number,
     error: Error | null,
-    response: Response | null
+    response: TResponse | null
   ) => number);
 
-  type RequestRetryOnFunction = ((
+  type RequestRetryOnFunction<TResponse> = ((
     attempt: number,
     error: Error | null,
-    response: Response | null
+    response: TResponse | null
   ) => boolean | Promise<boolean>);
 
-  export interface RequestInitWithRetry extends RequestInit {
+  interface RetryOptions<TResponse> {
     retries?: number;
-    retryDelay?: number | RequestDelayFunction;
-    retryOn?: number[] | RequestRetryOnFunction;
+    retryDelay?: number | RequestDelayFunction<TResponse>;
+    retryOn?: number[] | RequestRetryOnFunction<TResponse>;
   }
 
-  function fetchBuilder(fetch: typeof _fetch, defaults?: object): ((input: RequestInfo, init?: RequestInitWithRetry) => Promise<Response>);
+  export type RequestInitWithRetry<TFetch extends TFetchStub = typeof fetch> = RetryOptions<TFetchResponse<TFetch>> & TFetchInit<TFetch>;
+
+  type TFetchInput<TFetch> = TFetch extends (input: infer TInput, init?: any) => Promise<any> ? TInput : never;
+  type TFetchInit<TFetch> = TFetch extends (input: any, init?: infer TInit) => Promise<any> ? TInit : never;
+  type TFetchResponse<TFetch> = TFetch extends (input: any, init?: any) => Promise<infer TResponse> ? TResponse : never;
+  type TFetchStub = (input: any, init?: any) => Promise<any>;
+
+  function fetchBuilder<TFetch extends TFetchStub = typeof fetch>(fetch: TFetch, defaults?: RetryOptions<TFetchResponse<TFetch>>): ((input: TFetchInput<TFetch>, init?: RequestInitWithRetry<TFetch>) => Promise<TFetchResponse<TFetch>>);
   export default fetchBuilder;
 }

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = function (fetch, defaults) {
     return new Promise(function (resolve, reject) {
       var wrappedFetch = function (attempt) {
         var _input =
-          typeof Request !== 'undefined' && input instanceof Request
+          (typeof input === 'object' && input !==null && 'clone' in input && typeof input.clone === 'function')
             ? input.clone()
             : input;
         fetch(_input, init)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fetch-retry",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fetch-retry",
-      "version": "5.0.2",
+      "version": "6.0.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetch-retry",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "description": "Extend any fetch library with retry functionality",
   "repository": "https://github.com/jonbern/fetch-retry.git",
   "main": "index.js",


### PR DESCRIPTION
This PR fixes the https://github.com/jonbern/fetch-retry/issues/64 by inferring parameter\return types from the `fetch` argument.

This PR also introduces a BC: in will be impossible to change the `RequestInitWithRetry` interface in a module that uses this library in the following manner:

_type-overrides.d.ts_:
```TS
declare module 'fetch-retry' {
  export interface RequestInitWithRetry {
   some_new_field_here: string;
  }
}
```

---

With the current implementation, the module may be used as follows:

```TS
import {
  default as fetchBuilder,
  RequestInitWithRetry as RequestInitWithRetryBuilder 
} from 'fetch-retry';
import nodeFetch from 'node-fetch';

const fetch = fetchBuilder(nodeFetch, {
  retries: 0,
  retryDelay: 0,
  retryOn: (): boolean => false
});
export type RequestInitWithRetry = RequestInitWithRetryBuilder<typeof nodeFetch>;
```

When generic arg is not specified, types fall back to the ones defined in the global scope.