### PR TITLE
Fix type definition to allow passing URL or RequestInfo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,6 @@ declare module 'fetch-retry' {
     retryOn?: number[] | RequestRetryOnFunction;
   }
 
-  function fetchBuilder(fetch: typeof _fetch, defaults?: object): ((input: RequestInfo, init?: RequestInitWithRetry) => Promise<Response>);
+  function fetchBuilder(fetch: typeof _fetch, defaults?: object): ((input: Parameters<typeof _fetch>[0], init?: RequestInitWithRetry) => Promise<Response>);
   export default fetchBuilder;
 }


### PR DESCRIPTION
The current type definition doesn't allow passing a URL instance as input.

```ts
fetchWithRetry(new URL('https://example.com'))
// error: Argument of type 'URL' is not assignable to parameter of type 'RequestInfo'
```

This pr updates the type definitions to allow `RequestInfo|URL`