### PR TITLE
Type definition of the defaults parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,12 +15,14 @@ declare module 'fetch-retry' {
     response: Response | null
   ) => boolean | Promise<boolean>);
 
-  export interface RequestInitWithRetry extends RequestInit {
+  interface RequestInitRetryParams {
     retries?: number;
     retryDelay?: number | RequestDelayFunction;
     retryOn?: number[] | RequestRetryOnFunction;
   }
 
-  function fetchBuilder(fetch: typeof _fetch, defaults?: object): ((input: Parameters<typeof _fetch>[0], init?: RequestInitWithRetry) => Promise<Response>);
+  export type RequestInitWithRetry = RequestInit & RequestInitRetryParams;
+
+  function fetchBuilder(fetch: typeof _fetch, defaults?: RequestInitRetryParams): ((input: Parameters<typeof _fetch>[0], init?: RequestInitWithRetry) => Promise<Response>);
   export default fetchBuilder;
 }


### PR DESCRIPTION
Currently, the `defaults` parameter has type `object` which is too broad.

This PR brings definition for it, which are: `retries`, `retryDelay` and `retryOn` fields, with their types.
I defined a new interface `RequestInitRetryParams` with only these three fields, and so `RequestInitWithRetry` combines `RequestInit` and the new interface `RequestInitRetryParams`.